### PR TITLE
Make this look correct.

### DIFF
--- a/Timer.jsx
+++ b/Timer.jsx
@@ -1,43 +1,53 @@
-const { React, FluxDispatcher } = require('powercord/webpack');
+const { React, FluxDispatcher } = require("powercord/webpack");
 
 module.exports = class Timer extends React.Component {
-  constructor (props) {
+  constructor(props) {
     super(props);
     // ? Idk why I can't access 'this' in 'show', thanks god bind exists
     this.handleDispatch = this.handleDispatch.bind(this);
     this.state = {
       startTime: 0,
-      delta: 0
+      delta: 0,
     };
   }
 
-  handleDispatch (e) {
-    if (e.state && e.state === 'RTC_DISCONNECTED' && !e.hasOwnProperty('streamKey')) {
-      this.setState((prev) => (
-        prev.startTime = Date.now()));
+  handleDispatch(e) {
+    if (
+      e.state &&
+      e.state === "RTC_DISCONNECTED" &&
+      !e.hasOwnProperty("streamKey")
+    ) {
+      this.setState((prev) => (prev.startTime = Date.now()));
     }
   }
 
-  componentDidMount () {
-    this.setState((prev) => (
-      prev.startTime = Date.now()));
+  componentDidMount() {
+    this.setState((prev) => (prev.startTime = Date.now()));
 
     // ? Handles channel switches
-    FluxDispatcher.subscribe('RTC_CONNECTION_STATE', this.handleDispatch);
+    FluxDispatcher.subscribe("RTC_CONNECTION_STATE", this.handleDispatch);
 
     this.interval = setInterval(() => {
-      this.setState((prev) => (prev.delta = Math.round((Date.now() - prev.startTime) / 1000) * 1000));
+      this.setState(
+        (prev) =>
+          (prev.delta = Math.round((Date.now() - prev.startTime) / 1000) * 1000)
+      );
     }, 1000);
   }
 
   // Usually not needed but interval is being weird here ¯\_(ツ)_/¯
-  componentWillUnmount () {
-    FluxDispatcher.unsubscribe('RTC_CONNECTION_STATE', this.handleDispatch);
+  componentWillUnmount() {
+    FluxDispatcher.unsubscribe("RTC_CONNECTION_STATE", this.handleDispatch);
     clearInterval(this.interval);
   }
 
   // https://stackoverflow.com/questions/1322732/convert-seconds-to-hh-mm-ss-with-javascript
-  render () {
-    return <p>Time elapsed: {new Date(this.state.delta).toISOString().substr(11, 8)}</p>;
+  render() {
+    return (
+      <>
+        <br />
+        Time elapsed: {new Date(this.state.delta).toISOString().substr(11, 8)}
+      </>
+    );
   }
 };

--- a/Timer.jsx
+++ b/Timer.jsx
@@ -1,31 +1,31 @@
-const { React, FluxDispatcher } = require("powercord/webpack");
+const { React, FluxDispatcher } = require('powercord/webpack');
 
 module.exports = class Timer extends React.Component {
-  constructor(props) {
+  constructor (props) {
     super(props);
     // ? Idk why I can't access 'this' in 'show', thanks god bind exists
     this.handleDispatch = this.handleDispatch.bind(this);
     this.state = {
       startTime: 0,
-      delta: 0,
+      delta: 0
     };
   }
 
-  handleDispatch(e) {
+  handleDispatch (e) {
     if (
       e.state &&
-      e.state === "RTC_DISCONNECTED" &&
-      !e.hasOwnProperty("streamKey")
+      e.state === 'RTC_DISCONNECTED' &&
+      !e.hasOwnProperty('streamKey')
     ) {
       this.setState((prev) => (prev.startTime = Date.now()));
     }
   }
 
-  componentDidMount() {
+  componentDidMount () {
     this.setState((prev) => (prev.startTime = Date.now()));
 
     // ? Handles channel switches
-    FluxDispatcher.subscribe("RTC_CONNECTION_STATE", this.handleDispatch);
+    FluxDispatcher.subscribe('RTC_CONNECTION_STATE', this.handleDispatch);
 
     this.interval = setInterval(() => {
       this.setState(
@@ -36,13 +36,13 @@ module.exports = class Timer extends React.Component {
   }
 
   // Usually not needed but interval is being weird here ¯\_(ツ)_/¯
-  componentWillUnmount() {
-    FluxDispatcher.unsubscribe("RTC_CONNECTION_STATE", this.handleDispatch);
+  componentWillUnmount () {
+    FluxDispatcher.unsubscribe('RTC_CONNECTION_STATE', this.handleDispatch);
     clearInterval(this.interval);
   }
 
   // https://stackoverflow.com/questions/1322732/convert-seconds-to-hh-mm-ss-with-javascript
-  render() {
+  render () {
     return (
       <>
         <br />

--- a/Timer.jsx
+++ b/Timer.jsx
@@ -46,6 +46,7 @@ module.exports = class Timer extends React.Component {
     return (
       <>
         <br />
+        <br />
         Time elapsed: {new Date(this.state.delta).toISOString().substr(11, 8)}
       </>
     );

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "VCTimer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Shows how much time has passed since you joined a voice channel",
   "author": "RazerMoon",
   "license": "MIT"


### PR DESCRIPTION
Can we quit being fucking stupid and make this look similar to discord's way of doing it. Discord is not using a paragraph element to display the channel name above where vcTimer goes, instead they just slap some text in there. maybe do it that way so that it looks like it is actually supposed to fucking go there